### PR TITLE
fix: sync of bot on refresh

### DIFF
--- a/src/hooks/useRunningBots.ts
+++ b/src/hooks/useRunningBots.ts
@@ -32,6 +32,16 @@ export const useRunningBots = () => {
   };
 
   /**
+   * Sync running bots state with localStorage
+   * This is useful when localStorage is updated outside of this hook
+   */
+  const syncWithLocalStorage = () => {
+    const storedRunningBots = getStoredRunningBots();
+    setRunningBots(storedRunningBots);
+    return storedRunningBots;
+  };
+
+  /**
    * Add a running bot to the list
    * @param botId ID of the bot that is running
    * @param sessionId Session ID of the running bot
@@ -74,6 +84,7 @@ export const useRunningBots = () => {
     setRunningBots,
     getStoredRunningBots,
     updateLocalStorage,
+    syncWithLocalStorage,
     addRunningBot,
     removeRunningBot,
     isBotRunning,


### PR DESCRIPTION
This pull request introduces significant changes to the `Bots` component and the `useRunningBots` hook to improve synchronization between the application state and localStorage, and to verify bot trading status with the server. The most important changes include adding a new method to sync running bots with localStorage, verifying running bots with the server on component mount, and checking the trading status before starting a bot.

### Improvements to `Bots` component:

* Added `syncWithLocalStorage` method to `useRunningBots` hook and updated the `Bots` component to use this method for syncing running bots with localStorage. [[1]](diffhunk://#diff-14a7261dbf34eec473b50c1fa1c829d360e0f548ffda2ad24debbed3d7139c06L47-R48) [[2]](diffhunk://#diff-14c60799c6fb9db3bf1322ab2d905fbc237479f91338aa818df9238d435cba4dR34-R43) [[3]](diffhunk://#diff-14c60799c6fb9db3bf1322ab2d905fbc237479f91338aa818df9238d435cba4dR87)
* Implemented verification of running bots with the server on component mount to ensure the local state is consistent with the server's active sessions.
* Modified the `handleToggleBot` function to check the trading status with the server before starting a bot, ensuring no duplicate trading sessions are created.

### Codebase synchronization:

* Updated the dependency array of the `useEffect` hook to include `runningBots`, ensuring the effect runs when the running bots state changes.
* Enhanced the bot toggle logic to differentiate between local state and server state for running bots, providing more accurate feedback to users.